### PR TITLE
added dashboard component to hold children

### DIFF
--- a/src/dashboard/Dashboard.js
+++ b/src/dashboard/Dashboard.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react'
+import { Container, Section, Title } from 'bloomer'
+import NewsFeed from '../newsfeed/newsfeed';
+
+
+class Dashboard extends Component {
+
+
+    render() {
+        return (
+            <Container>
+                <Title>Dashboard</Title>
+                <NewsFeed />
+            </Container>
+        )
+    }
+}
+
+export default Dashboard

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ ReactDOM.render(
         <div>
             <NavBar />
             <Route path="/profile/:userId" component={UserProfile} />
+            <Route path="/:userId" component={Dashboard} />
         </div>
     </Router>
     , document.getElementById('root'));

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,10 @@ import ProfileView from './profile/ProfileView'
 import NewsFeed from './newsfeed/newsfeed'
 import ProfileHeader from './profile/ProfileHeader'
 import FriendList from './friends/FriendList'
+import Dashboard from './dashboard/Dashboard';
 
 
 
-ReactDOM.render(<ProfileView userId="1"/>, document.getElementById('root'));
+ReactDOM.render(<Dashboard userId="1"/>, document.getElementById('root'));
 // ReactDOM.render(<NewsFeed/>, document.getElementById('root'));
 registerServiceWorker();

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ ReactDOM.render(
         <div>
             <NavBar />
             <Route path="/profile/:userId" component={UserProfile} />
-            <Route path="/:userId" component={Dashboard} />
+            <Route path="/home/:userId" component={Dashboard} />
         </div>
     </Router>
     , document.getElementById('root'));

--- a/src/nav/NavBar.js
+++ b/src/nav/NavBar.js
@@ -15,7 +15,7 @@ class NavBar extends Component {
     render() {
         return (
         <Navbar>
-            <NavbarItem href={"/" + this.state.currentUser}>Home</NavbarItem>
+            <NavbarItem href={"/home/" + this.state.currentUser}>Home</NavbarItem>
             <Control>
                 <Input type="text" placeholder="Search"></Input>
             </Control>

--- a/src/nav/NavBar.js
+++ b/src/nav/NavBar.js
@@ -15,7 +15,7 @@ class NavBar extends Component {
     render() {
         return (
         <Navbar>
-            <NavbarItem href="/">Home</NavbarItem>
+            <NavbarItem href={"/" + this.state.currentUser}>Home</NavbarItem>
             <Control>
                 <Input type="text" placeholder="Search"></Input>
             </Control>


### PR DESCRIPTION
Added dashboard component so we have a place to put all the children components we are building for it. 

to test 
```
git fetch --all
git checkout rm-dashboard
```

1. make sure json server and npm dev server are running
1. when you click the home button on the navbar you should see a dashboard title and the newsfeed component as a child of it
1. check code.
1. there should be a dashboard component that currently only has one child, we will use this as the holder for all of our dashboard child componenets.
1. clicking the navitem currently hard coded as "jacob" should bring you to the profile view page.