### PR TITLE
added ability to search again without going back to home page

### DIFF
--- a/src/search/AllResults.js
+++ b/src/search/AllResults.js
@@ -12,9 +12,7 @@ class AllResults extends Component {
         events: []
     }
 
-    // fetch the collections for each search type based on search string
-    // and set state of related array
-    componentDidMount() {
+    runSearch = function() {
         fetch(`http://localhost:8088/posts?q=${this.props.searchString}&private=false&_expand=user`)
             .then(r => r.json())
             .then(response => {
@@ -36,6 +34,18 @@ class AllResults extends Component {
                     events: response
                 })
             })
+    }
+
+    // fetch the collections for each search type based on search string
+    // and set state of related array
+    componentDidMount() {
+        this.runSearch()
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps !== this.props) {
+            this.runSearch()
+        }
     }
 
     render() {

--- a/src/search/EventsResults.js
+++ b/src/search/EventsResults.js
@@ -9,7 +9,7 @@ class EventsResults extends Component {
         results: []
     }
 
-    componentDidMount() {
+    runSearch = function() {
         fetch(`http://localhost:8088/events?q=${this.props.searchString}`)
             .then(r => r.json())
 
@@ -18,6 +18,16 @@ class EventsResults extends Component {
                     results: response
                 })
             })
+    }
+
+    componentDidMount() {
+        this.runSearch()
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps !== this.props) {
+            this.runSearch()
+        }
     }
 
     render() {

--- a/src/search/PeopleResults.js
+++ b/src/search/PeopleResults.js
@@ -8,7 +8,7 @@ class PeopleResults extends Component {
         results: []
     }
 
-    componentDidMount() {
+    runSearch = function() {
         fetch(`http://localhost:8088/users?q=${this.props.searchString}`)
             .then(r => r.json())
 
@@ -17,6 +17,16 @@ class PeopleResults extends Component {
                     results: response
                 })
             })
+    }
+
+    componentDidMount() {
+        this.runSearch()
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (prevProps !== this.props) {
+            this.runSearch()
+        }
     }
 
     render() {

--- a/src/search/PostsResults.js
+++ b/src/search/PostsResults.js
@@ -9,7 +9,7 @@ class PostsResults extends Component {
         results: []
     }
 
-    componentDidMount() {
+    runSearch = function() {
         fetch(`http://localhost:8088/posts?q=${this.props.searchString}&private=false&_expand=user`)
             .then(r => r.json())
 
@@ -19,6 +19,18 @@ class PostsResults extends Component {
                 })
             })
     }
+
+    componentDidMount() {
+        this.runSearch()
+    }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps !== this.props) {
+            this.runSearch()
+        }
+    }
+
+
 
     render() {
         return (


### PR DESCRIPTION
added ability to re run search by typing in the search bar after your initial search

to test 
```
git fetch --all
git checkout rm-better-search
```

1. make sure api and npm dev server are running
1. run a search
1. without changing the search type via dropdown. start typing in the search bar. 
1. the results should auto update with each keystroke 
1. try it again with each of the current 4 search types in the dropdown.